### PR TITLE
Add ability to score double points

### DIFF
--- a/server/exe/AdminAPI.hs
+++ b/server/exe/AdminAPI.hs
@@ -30,7 +30,6 @@ import qualified Text.Blaze.Html5.Attributes as A
 
 import CategoriesWithFriends (ActiveGame(..))
 import qualified CategoriesWithFriends.Game as Game
-import qualified CategoriesWithFriends.Game.Answer as Answer
 import qualified CategoriesWithFriends.Game.Round as Round
 
 import Platform (Platform)
@@ -116,10 +115,10 @@ renderGame gameId ActiveGame{..} = renderHtml (Just gameId) $ do
   -- render all past games
   forM_ (reverse $ Game.getPastRounds game) $ \gameRound -> do
     renderRoundInfo gameRound "Finished"
-    renderAnswers gameRound (Round.getRatedAnswers gameRound) $ \(answer, result) ->
+    renderAnswers gameRound (Round.getRatedAnswers gameRound) $ \(answer, score) ->
       if Text.null answer
         then "--"
-        else Text.unwords [answer, if Answer.isValid result then "✔" else "✗"]
+        else Text.unwords [answer, if score > 0 then "✔" else "✗"]
   where
     renderGameInfo = do
       let showRoundNum = show . Round.roundNum . Round.getRoundInfo

--- a/server/exe/AdminAPI.hs
+++ b/server/exe/AdminAPI.hs
@@ -30,6 +30,7 @@ import qualified Text.Blaze.Html5.Attributes as A
 
 import CategoriesWithFriends (ActiveGame(..))
 import qualified CategoriesWithFriends.Game as Game
+import qualified CategoriesWithFriends.Game.Answer as Answer
 import qualified CategoriesWithFriends.Game.Round as Round
 
 import Platform (Platform)
@@ -115,10 +116,10 @@ renderGame gameId ActiveGame{..} = renderHtml (Just gameId) $ do
   -- render all past games
   forM_ (reverse $ Game.getPastRounds game) $ \gameRound -> do
     renderRoundInfo gameRound "Finished"
-    renderAnswers gameRound (Round.getRatedAnswers gameRound) $ \(answer, isValid) ->
+    renderAnswers gameRound (Round.getRatedAnswers gameRound) $ \(answer, result) ->
       if Text.null answer
         then "--"
-        else Text.unwords [answer, if isValid then "✔" else "✗"]
+        else Text.unwords [answer, if Answer.isValid result then "✔" else "✗"]
   where
     renderGameInfo = do
       let showRoundNum = show . Round.roundNum . Round.getRoundInfo

--- a/server/src/CategoriesWithFriends.hs
+++ b/server/src/CategoriesWithFriends.hs
@@ -33,7 +33,7 @@ import CategoriesWithFriends.ActiveGame (ActiveGame(..))
 import CategoriesWithFriends.Errors (ServerError(..))
 import CategoriesWithFriends.Events (Event(..))
 import CategoriesWithFriends.Game
-import CategoriesWithFriends.Game.Answer (Answer, AnswerRating)
+import CategoriesWithFriends.Game.Answer (Answer, AnswerRatings)
 import CategoriesWithFriends.Game.Category (Category)
 import CategoriesWithFriends.Game.Player (PlayerName)
 import CategoriesWithFriends.Game.Round (GameRoundStatus(..))
@@ -191,7 +191,7 @@ registerAnswers playerName playerAnswers activeGame@ActiveGame{game} =
     throwUnexpectedEvent = throwIO . UnexpectedEventError "submit_answers"
 
 -- | Register the given answer ratings and send the results to everyone.
-registerRatings :: Map PlayerName (Map Category AnswerRating) -> ActiveGame -> IO ActiveGame
+registerRatings :: AnswerRatings -> ActiveGame -> IO ActiveGame
 registerRatings ratings activeGame@ActiveGame{game} =
   case getState game of
     GameCreated -> throwUnexpectedEvent "game hasn't started"

--- a/server/src/CategoriesWithFriends.hs
+++ b/server/src/CategoriesWithFriends.hs
@@ -33,7 +33,7 @@ import CategoriesWithFriends.ActiveGame (ActiveGame(..))
 import CategoriesWithFriends.Errors (ServerError(..))
 import CategoriesWithFriends.Events (Event(..))
 import CategoriesWithFriends.Game
-import CategoriesWithFriends.Game.Answer (Answer)
+import CategoriesWithFriends.Game.Answer (Answer, AnswerRating)
 import CategoriesWithFriends.Game.Category (Category)
 import CategoriesWithFriends.Game.Player (PlayerName)
 import CategoriesWithFriends.Game.Round (GameRoundStatus(..))
@@ -191,7 +191,7 @@ registerAnswers playerName playerAnswers activeGame@ActiveGame{game} =
     throwUnexpectedEvent = throwIO . UnexpectedEventError "submit_answers"
 
 -- | Register the given answer ratings and send the results to everyone.
-registerRatings :: Map PlayerName (Map Category Bool) -> ActiveGame -> IO ActiveGame
+registerRatings :: Map PlayerName (Map Category AnswerRating) -> ActiveGame -> IO ActiveGame
 registerRatings ratings activeGame@ActiveGame{game} =
   case getState game of
     GameCreated -> throwUnexpectedEvent "game hasn't started"

--- a/server/src/CategoriesWithFriends/Events.hs
+++ b/server/src/CategoriesWithFriends/Events.hs
@@ -4,11 +4,12 @@ module CategoriesWithFriends.Events
   ( Event(..)
   ) where
 
+import Control.Monad (forM_, unless)
 import Data.Aeson (FromJSON(..), Value, withObject, (.:))
 import Data.Map.Strict (Map)
 import qualified Data.Text as Text
 
-import CategoriesWithFriends.Game.Answer (Answer, AnswerRating)
+import CategoriesWithFriends.Game.Answer (Answer)
 import CategoriesWithFriends.Game.Category (Category)
 import CategoriesWithFriends.Game.Player (PlayerName)
 
@@ -17,7 +18,7 @@ data Event
     -- ^ the host wants to start a round
   | SubmitAnswersEvent (Map Category Answer)
     -- ^ a player submitting their answers
-  | EndValidationEvent (Map PlayerName (Map Category AnswerRating))
+  | EndValidationEvent (Map PlayerName (Map Category Int))
     -- ^ a player has finished validating everyone's answers
   | SendToAllEvent Value
     -- ^ an arbitrary payload to send to all clients
@@ -29,6 +30,15 @@ instance FromJSON Event where
     case eventName of
       "start_round" -> pure StartRoundEvent
       "submit_answers" -> SubmitAnswersEvent <$> o .: "answers"
-      "end_validation" -> EndValidationEvent <$> o .: "votes"
+      "end_validation" -> do
+        scores <- o .: "scores"
+        validateScores scores
+        return $ EndValidationEvent scores
       "send_to_all" -> SendToAllEvent <$> o .: "payload"
       _ -> fail $ "Invalid event: " ++ Text.unpack eventName
+    where
+      validateScores scores =
+        forM_ scores $ \playerScores ->
+          forM_ playerScores $ \score ->
+            unless (0 <= score && score <= 2) $
+              fail "Score can only be a value between 0 - 2"

--- a/server/src/CategoriesWithFriends/Events.hs
+++ b/server/src/CategoriesWithFriends/Events.hs
@@ -8,7 +8,7 @@ import Data.Aeson (FromJSON(..), Value, withObject, (.:))
 import Data.Map.Strict (Map)
 import qualified Data.Text as Text
 
-import CategoriesWithFriends.Game.Answer (Answer)
+import CategoriesWithFriends.Game.Answer (Answer, AnswerRating)
 import CategoriesWithFriends.Game.Category (Category)
 import CategoriesWithFriends.Game.Player (PlayerName)
 
@@ -17,7 +17,7 @@ data Event
     -- ^ the host wants to start a round
   | SubmitAnswersEvent (Map Category Answer)
     -- ^ a player submitting their answers
-  | EndValidationEvent (Map PlayerName (Map Category Bool))
+  | EndValidationEvent (Map PlayerName (Map Category AnswerRating))
     -- ^ a player has finished validating everyone's answers
   | SendToAllEvent Value
     -- ^ an arbitrary payload to send to all clients

--- a/server/src/CategoriesWithFriends/Game.hs
+++ b/server/src/CategoriesWithFriends/Game.hs
@@ -43,7 +43,12 @@ import Data.Set (Set)
 import qualified Data.Set as Set
 
 import CategoriesWithFriends.Game.Answer
-    (AllAnswers, AllRatedAnswers, AnswerRatings, AnswersForPlayer)
+    ( AllAnswers
+    , AllRatedAnswers
+    , AnswerRating(..)
+    , AnswerRatings
+    , AnswersForPlayer
+    )
 import CategoriesWithFriends.Game.Player (PlayerName)
 import CategoriesWithFriends.Game.Round
     (GameRound, GameRoundInfo(roundNum), GameRoundStatus(..), generateRound)
@@ -102,7 +107,7 @@ getScores game = Map.unionsWith (+) $ emptyScores : pastScores
     emptyScores = Map.fromList . map (, 0) . getPlayers $ game
     pastScores = map scoreRound . pastRounds $ game
     scoreRound gameRound = scorePlayer <$> Round.getRatedAnswers gameRound
-    scorePlayer = Map.size . Map.filter ((== True) . snd)
+    scorePlayer = Map.size . Map.filter ((== True) . isValid . snd)
 
 getPastRounds :: Game status -> [GameRound 'RoundDone]
 getPastRounds = pastRounds

--- a/server/src/CategoriesWithFriends/Game.hs
+++ b/server/src/CategoriesWithFriends/Game.hs
@@ -107,7 +107,11 @@ getScores game = Map.unionsWith (+) $ emptyScores : pastScores
     emptyScores = Map.fromList . map (, 0) . getPlayers $ game
     pastScores = map scoreRound . pastRounds $ game
     scoreRound gameRound = scorePlayer <$> Round.getRatedAnswers gameRound
-    scorePlayer = Map.size . Map.filter ((== True) . isValid . snd)
+    scorePlayer = sum . Map.map scoreAnswer
+    scoreAnswer (_, AnswerRating{..})
+      | not isValid = 0
+      | worthDouble = 2
+      | otherwise = 1
 
 getPastRounds :: Game status -> [GameRound 'RoundDone]
 getPastRounds = pastRounds

--- a/server/src/CategoriesWithFriends/Game.hs
+++ b/server/src/CategoriesWithFriends/Game.hs
@@ -43,12 +43,7 @@ import Data.Set (Set)
 import qualified Data.Set as Set
 
 import CategoriesWithFriends.Game.Answer
-    ( AllAnswers
-    , AllRatedAnswers
-    , AnswerRating(..)
-    , AnswerRatings
-    , AnswersForPlayer
-    )
+    (AllAnswers, AllRatedAnswers, AnswerRatings, AnswersForPlayer)
 import CategoriesWithFriends.Game.Player (PlayerName)
 import CategoriesWithFriends.Game.Round
     (GameRound, GameRoundInfo(roundNum), GameRoundStatus(..), generateRound)
@@ -107,11 +102,7 @@ getScores game = Map.unionsWith (+) $ emptyScores : pastScores
     emptyScores = Map.fromList . map (, 0) . getPlayers $ game
     pastScores = map scoreRound . pastRounds $ game
     scoreRound gameRound = scorePlayer <$> Round.getRatedAnswers gameRound
-    scorePlayer = sum . Map.map scoreAnswer
-    scoreAnswer (_, AnswerRating{..})
-      | not isValid = 0
-      | worthDouble = 2
-      | otherwise = 1
+    scorePlayer = sum . Map.map snd
 
 getPastRounds :: Game status -> [GameRound 'RoundDone]
 getPastRounds = pastRounds

--- a/server/src/CategoriesWithFriends/Game/Answer.hs
+++ b/server/src/CategoriesWithFriends/Game/Answer.hs
@@ -53,18 +53,23 @@ data AnswerInfo (status :: AnswerStatus) where
 {- Validation Result -}
 
 data AnswerRating = AnswerRating
-  { isValid :: Bool
+  { isValid     :: Bool
+  , worthDouble :: Bool
+    -- ^ If True, this answer deserves double points, for when an answer is
+    -- alliterative
   } deriving (Show)
 
 instance ToJSON AnswerRating where
   toJSON AnswerRating{..} = object
     [ "is_valid" .= isValid
+    , "worth_double" .= worthDouble
     ]
 
 instance FromJSON AnswerRating where
   parseJSON = withObject "AnswerRating" $ \o ->
     AnswerRating
       <$> o .: "is_valid"
+      <*> o .: "worth_double"
 
 {- Queries -}
 

--- a/server/src/CategoriesWithFriends/Game/Round.hs
+++ b/server/src/CategoriesWithFriends/Game/Round.hs
@@ -46,7 +46,7 @@ data GameRoundInfo = GameRoundInfo
   , categories :: [Category]
   , letter     :: Char
   , deadline   :: UTCTime
-  }
+  } deriving (Show)
 
 data GameRoundStatus = RoundBeingAnswered | RoundBeingRated | RoundDone
 

--- a/server/src/CategoriesWithFriends/Messages.hs
+++ b/server/src/CategoriesWithFriends/Messages.hs
@@ -25,17 +25,11 @@ data Message
   | EndRoundMessage GameRoundInfo AllRatedAnswers (Map PlayerName Int) Bool
     -- ^ send the results of the game so far
   | SendToAllMessage Value
-
-instance Show Message where
-  show RefreshPlayerListMessage{} = "refresh_player_list"
-  show StartRoundMessage{} = "start_round"
-  show StartValidationMessage{} = "start_validation"
-  show EndRoundMessage{} = "end_round"
-  show SendToAllMessage{} = "send_to_all"
+  deriving (Show)
 
 instance ToJSON Message where
   toJSON message =
-    let eventEntry = "event" .= show message
+    let eventEntry = "event" .= messageId message
     in object $ eventEntry : mkMessagePayload message
     where
       mkMessagePayload = \case
@@ -62,5 +56,13 @@ instance ToJSON Message where
         SendToAllMessage payload ->
           [ "payload" .= payload
           ]
+
+      messageId :: Message -> String
+      messageId = \case
+        RefreshPlayerListMessage{} -> "refresh_player_list"
+        StartRoundMessage{} -> "start_round"
+        StartValidationMessage{} -> "start_validation"
+        EndRoundMessage{} -> "end_round"
+        SendToAllMessage{} -> "send_to_all"
 
       formatISO8601 = formatTime defaultTimeLocale (iso8601DateFormat (Just "%H:%M:%S"))


### PR DESCRIPTION
Related to #27 

@matthew-chinn this breaks front-end code. Can you fix the front-end API to use `{ is_valid: boolean, worth_double: boolean }` instead of just `boolean` for answer ratings? you don't have to implement the double points yet (you can hard code `worth_double` to false), but just make the API change.