### PR TITLE
Forcibly lock answers after 5 seconds past the round ending

### DIFF
--- a/server/src/CategoriesWithFriends.hs
+++ b/server/src/CategoriesWithFriends.hs
@@ -21,7 +21,7 @@ import Data.Aeson (FromJSON, ToJSON, eitherDecode', encode)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe)
-import Data.Time (addUTCTime, getCurrentTime)
+import Data.Time (UTCTime, addUTCTime, getCurrentTime)
 import Network.WebSockets
     ( Connection
     , ConnectionException(..)
@@ -118,10 +118,14 @@ servePlayer activeGameVar playerName playerConn cleanupGame =
       return $ activeGame { playerState = updatedPlayerState }
 
 hasTimedOut :: ActiveGame -> IO Bool
-hasTimedOut ActiveGame{startTime} = do
+hasTimedOut = timeIsEarlierThan 3600 . startTime
+
+-- | Return True if the given time is past the given duration (in
+-- seconds) ago.
+timeIsEarlierThan :: Int -> UTCTime -> IO Bool
+timeIsEarlierThan duration time = do
   now <- getCurrentTime
-  let gameTimeout = 3600 -- 1 hour
-  return $ addUTCTime gameTimeout startTime < now
+  return $ addUTCTime (fromIntegral duration) time < now
 
 {- Game mechanics -}
 

--- a/server/src/CategoriesWithFriends.hs
+++ b/server/src/CategoriesWithFriends.hs
@@ -66,9 +66,9 @@ servePlayer activeGameVar playerName playerConn cleanupGame =
               -- if so, and if player hasn't answered yet, register their
               -- answers as no answers
               hasRoundExpired <- timeIsEarlierThan 5 . deadline . getRoundInfo $ game
-              if not hasRoundExpired || hasPlayerAnswered playerName game
-                then return activeGame
-                else registerAnswers playerName mempty activeGame
+              if hasRoundExpired
+                then setGameAndMessageAll (forceLockAnswers game) startValidationMessage activeGame
+                else return activeGame
             _ -> return activeGame
 
         Just event -> do

--- a/server/src/CategoriesWithFriends/Game.hs
+++ b/server/src/CategoriesWithFriends/Game.hs
@@ -29,6 +29,7 @@ module CategoriesWithFriends.Game
     -- * Starting a round
   , startRound
     -- * Handle player answers
+  , hasPlayerAnswered
   , addAnswers
   , AddAnswersResult(..)
   , rateAnswers
@@ -185,6 +186,9 @@ startRound game = do
   return $ game { state = GameRoundBeingAnswered gameRound }
 
 {- Handle player answers -}
+
+hasPlayerAnswered :: PlayerName -> Game ('GameRunning 'RoundBeingAnswered) -> Bool
+hasPlayerAnswered playerName = withCurrRound (Round.hasPlayerAnswered playerName)
 
 data AddAnswersResult
   = WaitForOtherPlayers (Game ('GameRunning 'RoundBeingAnswered))

--- a/server/src/CategoriesWithFriends/Game/Answer.hs
+++ b/server/src/CategoriesWithFriends/Game/Answer.hs
@@ -16,6 +16,7 @@ module CategoriesWithFriends.Game.Answer
   , getRatedAnswers
     -- * Actions
   , initAnswers
+  , hasPlayerAnswered
   , AnswersForPlayer
   , addAnswers
   , AnswerRatings
@@ -24,6 +25,7 @@ module CategoriesWithFriends.Game.Answer
 
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
+import Data.Maybe (isJust)
 import Data.Text (Text)
 
 import CategoriesWithFriends.Game.Category (Category)
@@ -73,6 +75,17 @@ initAnswers players categories = PlayerAnswers $
   Map.fromList $ map (, emptyAnswers) players
   where
     emptyAnswers = Map.fromList $ map (, MaybeAnswer Nothing) categories
+
+-- | Return True if the given player has answered already.
+hasPlayerAnswered :: PlayerName -> PlayerAnswers 'AnswersAccepted -> Bool
+hasPlayerAnswered playerName = checkAnswers . Map.lookup playerName . unPlayerAnswers
+  where
+    checkAnswers = \case
+      Nothing -> error $ "Player not found: " ++ show playerName
+      Just playerAnswers -> all (isJust . fromMaybeAnswer) playerAnswers
+
+    fromMaybeAnswer :: AnswerInfo 'AnswersAccepted -> Maybe Answer
+    fromMaybeAnswer (MaybeAnswer answer) = answer
 
 type AnswersForPlayer = Map Category Answer
 

--- a/server/src/CategoriesWithFriends/Game/Round.hs
+++ b/server/src/CategoriesWithFriends/Game/Round.hs
@@ -9,12 +9,12 @@ module CategoriesWithFriends.Game.Round
   , GameRoundStatus(..)
     -- * Queries
   , getRoundInfo
-  , hasPlayerAnswered
   , getAnswers
   , getRatedAnswers
     -- * Actions
   , generateRound
   , addAnswers
+  , forceLockAnswers
   , rateAnswers
   ) where
 
@@ -60,9 +60,6 @@ type family GameRoundAnswerStatus (status :: GameRoundStatus) :: AnswerStatus wh
 
 getRoundInfo :: GameRound status -> GameRoundInfo
 getRoundInfo = roundInfo
-
-hasPlayerAnswered :: PlayerName -> GameRound 'RoundBeingAnswered -> Bool
-hasPlayerAnswered playerName = Answer.hasPlayerAnswered playerName . answers
 
 getAnswers :: GameRound 'RoundBeingRated -> AllAnswers
 getAnswers = Answer.getAnswers . answers
@@ -128,6 +125,12 @@ addAnswers playerName playerAnswers gameRound =
   where
     updateRound (Right lockedAnswers) = Right gameRound { answers = lockedAnswers }
     updateRound (Left updatedAnswers) = Left gameRound { answers = updatedAnswers }
+
+-- | Force lock the answers of everyone who hasn't answered yet.
+forceLockAnswers :: GameRound 'RoundBeingAnswered -> GameRound 'RoundBeingRated
+forceLockAnswers gameRound = updateRound . Answer.forceLockAnswers . answers $ gameRound
+  where
+    updateRound lockedAnswers = gameRound { answers = lockedAnswers }
 
 -- | Set the given ratings for the players' answers. Errors if an answer for a
 -- player and category does not exist in the input.

--- a/server/src/CategoriesWithFriends/Game/Round.hs
+++ b/server/src/CategoriesWithFriends/Game/Round.hs
@@ -9,6 +9,7 @@ module CategoriesWithFriends.Game.Round
   , GameRoundStatus(..)
     -- * Queries
   , getRoundInfo
+  , hasPlayerAnswered
   , getAnswers
   , getRatedAnswers
     -- * Actions
@@ -59,6 +60,9 @@ type family GameRoundAnswerStatus (status :: GameRoundStatus) :: AnswerStatus wh
 
 getRoundInfo :: GameRound status -> GameRoundInfo
 getRoundInfo = roundInfo
+
+hasPlayerAnswered :: PlayerName -> GameRound 'RoundBeingAnswered -> Bool
+hasPlayerAnswered playerName = Answer.hasPlayerAnswered playerName . answers
 
 getAnswers :: GameRound 'RoundBeingRated -> AllAnswers
 getAnswers = Answer.getAnswers . answers


### PR DESCRIPTION
Fixes a bug where if a player gets disconnected, all the other players couldn't move on because a player was not locked yet.

cc @matthew-chinn 